### PR TITLE
Making "session" object as a public variable

### DIFF
--- a/SwiftNetwork/Classes/Networking.swift
+++ b/SwiftNetwork/Classes/Networking.swift
@@ -144,7 +144,7 @@ public class Networking {
      */
     let boundary = String(format: "net.3lvis.networking.%08x%08x", arc4random(), arc4random())
     
-    lazy var session: URLSession = {
+    public lazy var session: URLSession = {
         return URLSession(configuration: self.sessionConfiguration())
     }()
     


### PR DESCRIPTION
For the purpose of testing, making session object as a public variable. Doing so would allow using customised URLProtocol instead of default one. That way server response can be mocked.